### PR TITLE
Only pass INTERNAL_INCLUDE_DIRS to header file language check.

### DIFF
--- a/IncludeWhatYouUse.cmake
+++ b/IncludeWhatYouUse.cmake
@@ -55,10 +55,6 @@ function (iwyu_target_sources TARGET)
 
     psq_get_target_command_attach_point (${TARGET} WHEN)
 
-    set (ALL_INCLUDE_DIRS
-         ${IWYU_SOURCES_EXTERNAL_INCLUDE_DIRS}
-         ${IWYU_SOURCES_INTERNAL_INCLUDE_DIRS})
-
     psq_append_each_to_options_with_prefix (IWYU_TARGET_ARGS
                                             -isystem
                                             LIST ${IWYU_SOURCES_EXTERNAL_INCLUDE_DIRS})
@@ -74,7 +70,8 @@ function (iwyu_target_sources TARGET)
                          MULTIVAR_ARGS CPP_IDENTIFIERS)
 
     psq_sort_sources_to_languages (C_SOURCES CXX_SOURCES HEADERS
-                                   INCLUDES ${ALL_INCLUDE_DIRS}
+                                   INCLUDES
+                                   ${IWYU_SOURCES_INTERNAL_INCLUDE_DIRS}
                                    SOURCES ${FILES_TO_CHECK}
                                    ${DETERMINE_LANG_FORWARD_OPTIONS})
 


### PR DESCRIPTION
We don't care about headers in external include dirs potentially including our
local headers - that is never going to happen, they are never going to be
scanned and it takes an extraordinary amount of resources to scan all of them
(eg, boost)
